### PR TITLE
fix: Use --keep-in-foreground instead of --no-daemon

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,4 +48,4 @@ if [ ! -f "$conf" ]; then
 
 fi
 
-exec dnsmasq "--conf-file=$conf" --no-daemon --no-resolv
+exec dnsmasq "--conf-file=$conf" --keep-in-foreground --log-facility=- --no-resolv


### PR DESCRIPTION
Per the dnsmasq [man page](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html) for -d/--no-daemon:

> Note that this option is for use in debugging only, to stop dnsmasq daemonising in production, use --keep-in-foreground.

Debug mode also disables forking for TCP queries, so a single client that opens TCP/53 and then stops responding blocks the single-threaded main process indefinitely. All DNS stops being served, UDP included, while the container still looks healthy. See [my comment](https://github.com/dockur/dnsmasq/issues/7#issuecomment-5350066920) on #7.

Also add --log-facility=- to preserve the stderr logging that debug mode was providing, so `docker logs` keeps working.